### PR TITLE
Slim down plus composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,23 @@
   "scripts": {
     "compileTypescript": "mkdir -p ./target-typescript && tsc",
     "compileBrowserify": "mkdir -p ./target && browserify ./target-typescript/example.js --outfile ./target/example.js",
+    "test": "mocha  --compilers ts:ts-node/register `((test -z $WATCH) && :)` src/test.ts",
     "copyHtml": "cp ./src/index.html ./target/index.html",
     "tslint": "tslint --exclude 'node_modules/**' '**/*.ts'",
     "clean": "rm -rf ./target ./target-typescript",
     "compile": "npm run clean && npm run tslint && npm run compileTypescript && npm run compileBrowserify && npm run copyHtml"
   },
   "main": "src/redux-reducer-effects.ts",
-  "dependencies": {
-    "@types/redux": "^3.5.29",
-    "monapt": "^0.5.4"
-  },
   "devDependencies": {
+    "@types/redux": "^3.5.29",
+    "@types/chai": "^3.4.32",
+    "@types/mocha": "^2.2.31",
     "@types/whatwg-fetch": "0.0.30",
     "browserify": "^13.1.0",
+    "chai": "^3.5.0",
+    "mocha": "^3.0.2",
     "redux": "^3.6.0",
+    "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
     "typescript": "^2.0.2",
     "typings": "^1.3.3"

--- a/src/redux-reducer-effects.ts
+++ b/src/redux-reducer-effects.ts
@@ -10,7 +10,7 @@ type EnhancedReducersMapObject<Task> = {
     [key: string]: EnhancedReducer<any, Task>;
 }
 
-export type Result<State,Task> = State | [State,Task];
+export type Result<State,Task> = State | [State,Task | Task[]];
 
 type TaskCallback<T> = (task: T) => any
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,57 +4,56 @@ import { assert } from "chai";
 type Action = { type : string};
 type Task = { task: string };
 type State = {
-  counter: number,
+    counter: number,
 };
 
 describe("redux-reducer-effects", function() {
 
-  describe("compose reducers", function() {
+    describe("compose reducers", function() {
 
-    it("keeps all state changes", function() {
-      const combined = composeReducers(increment, increment, increment);
+        it("keeps all state changes", function() {
+            const combined = composeReducers(increment, increment, increment);
 
-      const [state, _ts] = <any>(combined({ counter: 0 }, { type: "init" }));
-      assert(state, "expected final state");
-      assert.equal(state.counter, 3);
+            const [state, _ts] = <any>(combined({ counter: 0 }, { type: "init" }));
+            assert(state, "expected final state");
+            assert.equal(state.counter, 3);
 
-      function increment(s: State, action: Action) {
-        return {
-          counter: s.counter + 1,
-        }
-      }
+            function increment(s: State, action: Action) {
+                return {
+                    counter: s.counter + 1,
+                }
+            }
+        })
+
+        it("combines tasks, from both states with and without new tasks", function() {
+            const combined = composeReducers(increment, incrementWithTask, increment, incrementWithTask);
+            const stubTask = () => ({ task: "do thing" });
+
+            const [state, tasks] = <any>combined({ counter: 0 }, { type: "init" });
+
+            assert(state, "expected final state");
+            assert.equal(state.counter, 4);
+            assert.deepEqual(tasks, [stubTask(), stubTask()]);
+
+            function increment(s: State, action: Action) {
+                return {
+                    counter: s.counter + 1,
+                }
+            }
+
+            function incrementWithTask(s: State, action: Action): Result<State, Task> {
+                return [{
+                    counter: s.counter + 1,
+                }, stubTask()]
+            }
+        })
+
+            
     })
 
-    it("combines tasks, from both states with and without new tasks", function() {
-      const combined = composeReducers(increment, incrementWithTask, increment, incrementWithTask);
-      const stubTask = () => ({ task: "do thing" });
+    describe("combine reducers", function() {
 
-      const [state, tasks] = <any>combined({ counter: 0 }, { type: "init" });
-
-      assert(state, "expected final state");
-      assert.equal(state.counter, 4);
-      assert.deepEqual(tasks, [stubTask(), stubTask()]);
-
-      function increment(s: State, action: Action) {
-        return {
-          counter: s.counter + 1,
-        }
-      }
-
-      function incrementWithTask(s: State, action: Action): Result<State, Task> {
-        return [{
-          counter: s.counter + 1,
-        }, stubTask()]
-      }
+            
     })
-
-      
-  })
-
-  describe("combine reducers", function() {
-
-      
-  })
-    
 })
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,59 @@
+import { composeReducers } from "./redux-reducer-effects";
+import { assert } from "chai";
+
+type Action = { type : string};
+type State = {
+  counter: number,
+};
+
+describe("redux-reducer-effects", function() {
+
+  describe("compose reducers", function() {
+
+    it("keeps all state changes", function() {
+      const combined = composeReducers(increment, increment, increment);
+
+      const [state, _ts] = <any>(combined({ counter: 0 }, { type: "init" }));
+      assert(state, "expected final state");
+      assert.equal(state.counter, 3);
+
+      function increment(s: State, action: Action) {
+        return {
+          counter: s.counter + 1,
+        }
+      }
+    })
+
+    it("combines tasks, from both states with and without new tasks", function() {
+      const combined = composeReducers(increment, incrementWithTask, increment, incrementWithTask);
+      const stubTask = () => ({ task: "do thing" });
+
+      const [state, tasks] = <any>combined({ counter: 0 }, { type: "init" });
+
+      assert(state, "expected final state");
+      assert.equal(state.counter, 4);
+      assert.deepEqual(tasks, [stubTask(), stubTask()]);
+
+      function increment(s: State, action: Action) {
+        return {
+          counter: s.counter + 1,
+        }
+      }
+
+      function incrementWithTask(s: State, action: Action) {
+        return [{
+          counter: s.counter + 1,
+        }, stubTask()]
+      }
+    })
+
+      
+  })
+
+  describe("combine reducers", function() {
+
+      
+  })
+    
+})
+

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,7 +1,8 @@
-import { composeReducers } from "./redux-reducer-effects";
+import { composeReducers, Result } from "./redux-reducer-effects";
 import { assert } from "chai";
 
 type Action = { type : string};
+type Task = { task: string };
 type State = {
   counter: number,
 };
@@ -40,7 +41,7 @@ describe("redux-reducer-effects", function() {
         }
       }
 
-      function incrementWithTask(s: State, action: Action) {
+      function incrementWithTask(s: State, action: Action): Result<State, Task> {
         return [{
           counter: s.counter + 1,
         }, stubTask()]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         ]
     },
     "files": [
+        "./src/test.ts",
         "./src/example.ts"
     ]
 }


### PR DESCRIPTION
What do you think of this? I made a few changes while adding `composeReducers`, that reduce the libraries runtime, code-size and conceptual overhead:
- monapt -> a few helper methods
  - fewer runtime deps, and less boiler-plate on the reducers (e.g `new Some`)
- now works with old-style reducers unchanged! :)
- add `composeReducers`, with tests

One hitch remaining: can the reducers that return the pairs be infered? Seems like I needed to add the `Result` typing - I suppose that's only once per reducer, so not too much of a biggy.
