### PR TITLE
New task runner: restore type safety + example

### DIFF
--- a/src/redux-reducer-effects.ts
+++ b/src/redux-reducer-effects.ts
@@ -46,12 +46,12 @@ export interface Subject<T> extends Observable<T> {
     flatMap<R>(project: (value: T, index: number) => Observable<R>): Observable<R>;
 }
 
+export type TaskRunner<Task, Msg> = (task$: Observable<Task>) => Observable<Msg>;
+
 export interface EnhanceOptions<Task, Msg> {
     createSubject(): Subject<Task>
     taskRunner: TaskRunner<Task, Msg>,
 };
-
-export type TaskRunner<Task, Msg> = (task$: Observable<Task>) => Observable<Msg>;
 
 const enhance = <Task, Msg extends Action>(options: EnhanceOptions<Task, Msg>) => (originalCreateStore: StoreCreator) => {
     const { createSubject, taskRunner } = options;

--- a/src/test.ts
+++ b/src/test.ts
@@ -26,9 +26,9 @@ describe("redux-reducer-effects", function() {
             store.dispatch({ type: "asyncInc" });
 
             return wait(5)
-              .then(() => {
-                  assert.deepEqual(store.getState(), { counter: 1 });
-              })
+                .then(() => {
+                    assert.deepEqual(store.getState(), { counter: 1 });
+                })
 
             function reducer(state: State, action: Action): EnhancedReducerResult<State,Task> {
                 switch(action.type) {
@@ -44,9 +44,9 @@ describe("redux-reducer-effects", function() {
             }
 
             function taskRunner(task$: Observable<Task>): Observable<Action> {
-              return task$
-                  .map(() => ({ type: "increment" }))
-                  .observeOn(Scheduler.async)
+                return task$
+                    .map(() => ({ type: "increment" }))
+                    .observeOn(Scheduler.async)
             }
 
 
@@ -107,5 +107,5 @@ describe("redux-reducer-effects", function() {
 
 
 function wait(n: number) {
-  return new Promise(resolve => setTimeout(resolve, n));
+    return new Promise(resolve => setTimeout(resolve, n));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
         ]
     },
     "files": [
-        "./src/test.ts"
+        "./src/test.ts",
+        "./src/example.ts"
     ]
 }


### PR DESCRIPTION
This PR:
- restores type safety which we lost some of in the work to add observables to the task runner. Previously it was possible to define a task runner with any input and any output as long as it had the Observable interface. Now the task runner's input/output observables will be type checked against the user's `Action` and `Task` generics (respectively).
- restores the example, which I'm keen to keep up to date to help me test new ideas.

~~The diff is a hard to read here because I rebased your branch on top of master, and I didn't want to force push to your branch without you knowing. Until master has been merged/rebased into the base branch, please view diff at https://github.com/cubik-oss/redux-reducer-effects/compare/9a55bb477d985e03f1f98e0351d21671ad139c69...oja-composeable-observable instead.~~
**Update:** this now merges into a temporary branch `oja-composeable-observable-with-master`, which is equal to `composeable-observable` rebased on `master`.

I'm going to start writing some documentation for the project and advertising it! 😄 
